### PR TITLE
[#2750] Torrents resuming after recheck, fix.

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -968,6 +968,7 @@ class TorrentManager(component.Component):
             torrent.forcing_recheck = False
             if torrent.forcing_recheck_paused:
                 torrent.handle.pause()
+                torrent.pause()
 
         # Set the torrent state
         torrent.update_state()


### PR DESCRIPTION
Quick fix to the issue of torrents not remembering their paused state after a force recheck.
Proposed fix for: http://dev.deluge-torrent.org/ticket/2750